### PR TITLE
feat: add prototype login/logout flow

### DIFF
--- a/db.json
+++ b/db.json
@@ -1,10 +1,19 @@
 {
+  "users": [
+    {
+      "id": "1",
+      "loginId": "demo",
+      "password": "1234",
+      "name": "데모 사용자"
+    }
+  ],
   "profile": [
     {
       "id": "1",
+      "userId": "1",
       "userName": "강태규",
       "monthlyIncome": 3000000,
-      "targetExpenseRatio": 40,
+      "targetExpenseRatio": 75,
       "currentPigLevel": 5,
       "houseLevel": 1,
       "createdAt": "2026-04-07"

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,19 +1,36 @@
 <script setup>
-import { onMounted } from 'vue'
+import { computed, watch } from 'vue'
+import { useRoute } from 'vue-router'
 import NavBar from './components/NavBar.vue'
 import { useBudgetStore } from './stores/useBudgetStore.js'
+import { useAuthStore } from './stores/useAuthStore.js'
 
+const route = useRoute()
 const store = useBudgetStore()
+const authStore = useAuthStore()
 
-onMounted(async () => {
-  await store.initStore()
-})
+const showNavBar = computed(() =>
+  authStore.isAuthenticated && route.meta.hideNav !== true
+)
+
+watch(
+  () => authStore.currentUser?.id,
+  async (userId) => {
+    if (!userId) {
+      store.resetStore()
+      return
+    }
+
+    await store.initStore(userId)
+  },
+  { immediate: true }
+)
 </script>
 
 <template>
-  <div id="app-wrapper">
-    <NavBar />
-    <main class="main-content">
+  <div id="app-wrapper" :class="{ 'login-layout': !showNavBar }">
+    <NavBar v-if="showNavBar" />
+    <main class="main-content" :class="{ compact: !showNavBar }">
       <RouterView />
     </main>
   </div>
@@ -27,11 +44,19 @@ onMounted(async () => {
   background: var(--bg-main);
 }
 
+#app-wrapper.login-layout {
+  justify-content: center;
+}
+
 .main-content {
   flex: 1;
   padding: 1.5rem 1rem 5rem;
   max-width: 480px;
   width: 100%;
   margin: 0 auto;
+}
+
+.main-content.compact {
+  padding-bottom: 1.5rem;
 }
 </style>

--- a/src/pages/LoginPage.vue
+++ b/src/pages/LoginPage.vue
@@ -1,0 +1,205 @@
+<script setup>
+import { reactive, ref } from 'vue'
+import { useRouter } from 'vue-router'
+import { useAuthStore } from '../stores/useAuthStore.js'
+
+const router = useRouter()
+const authStore = useAuthStore()
+
+const form = reactive({
+  loginId: '',
+  password: '',
+})
+
+const formError = ref('')
+
+async function handleLogin() {
+  formError.value = ''
+
+  if (!form.loginId.trim() || !form.password.trim()) {
+    formError.value = '아이디와 비밀번호를 모두 입력해 주세요.'
+    return
+  }
+
+  try {
+    await authStore.login(form.loginId.trim(), form.password)
+    router.push('/')
+  } catch {
+    formError.value = authStore.error
+  }
+}
+</script>
+
+<template>
+  <section class="login-page">
+    <div class="login-card">
+      <div class="login-badge">Don-Doc</div>
+      <h1 class="login-title">돈독한 소비 습관을 위한 로그인</h1>
+      <p class="login-subtitle">
+        기존 가계부 테마에 맞춘 분홍 톤으로, 오늘 기록부터 바로 이어서 관리할 수 있어요.
+      </p>
+
+      <div class="demo-box">
+        <p class="demo-title">테스트 계정</p>
+        <p class="demo-value">아이디 demo / 비밀번호 1234</p>
+      </div>
+
+      <form class="login-form" @submit.prevent="handleLogin">
+        <label class="field">
+          <span class="field-label">아이디</span>
+          <input
+            v-model="form.loginId"
+            type="text"
+            class="field-input"
+            placeholder="아이디를 입력해 주세요"
+            autocomplete="username"
+          />
+        </label>
+
+        <label class="field">
+          <span class="field-label">비밀번호</span>
+          <input
+            v-model="form.password"
+            type="password"
+            class="field-input"
+            placeholder="비밀번호를 입력해 주세요"
+            autocomplete="current-password"
+          />
+        </label>
+
+        <p v-if="formError" class="error-text">{{ formError }}</p>
+
+        <button type="submit" class="login-button" :disabled="authStore.loading">
+          {{ authStore.loading ? '로그인 중...' : '로그인' }}
+        </button>
+      </form>
+    </div>
+  </section>
+</template>
+
+<style scoped>
+.login-page {
+  min-height: calc(100vh - 3rem);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.login-card {
+  width: 100%;
+  background:
+    radial-gradient(circle at top right, rgba(255, 179, 71, 0.25), transparent 28%),
+    linear-gradient(180deg, #ffffff 0%, #fff7fb 100%);
+  border: 1.5px solid var(--border);
+  border-radius: 28px;
+  box-shadow: var(--shadow);
+  padding: 2rem 1.25rem;
+}
+
+.login-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 92px;
+  padding: 0.35rem 0.85rem;
+  border-radius: 999px;
+  background: var(--primary-light);
+  color: var(--primary-dark);
+  font-size: 0.82rem;
+  font-weight: 800;
+  letter-spacing: 0.04em;
+}
+
+.login-title {
+  margin: 1rem 0 0.55rem;
+  font-size: 1.8rem;
+  line-height: 1.25;
+  color: var(--text);
+}
+
+.login-subtitle {
+  color: var(--text-muted);
+  font-size: 0.92rem;
+}
+
+.demo-box {
+  margin-top: 1.25rem;
+  padding: 0.9rem 1rem;
+  background: rgba(255, 107, 157, 0.08);
+  border: 1px solid rgba(255, 107, 157, 0.14);
+  border-radius: 18px;
+}
+
+.demo-title {
+  font-size: 0.78rem;
+  font-weight: 700;
+  color: var(--primary-dark);
+}
+
+.demo-value {
+  margin-top: 0.2rem;
+  font-size: 0.9rem;
+  color: var(--text);
+}
+
+.login-form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.9rem;
+  margin-top: 1.4rem;
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.field-label {
+  font-size: 0.82rem;
+  font-weight: 700;
+  color: var(--text-muted);
+}
+
+.field-input {
+  width: 100%;
+  border: 1.5px solid var(--border);
+  border-radius: 14px;
+  padding: 0.9rem 1rem;
+  background: #fff;
+  outline: none;
+  transition: border-color 0.2s, box-shadow 0.2s;
+}
+
+.field-input:focus {
+  border-color: var(--primary);
+  box-shadow: 0 0 0 4px rgba(255, 107, 157, 0.12);
+}
+
+.error-text {
+  color: #e53935;
+  font-size: 0.82rem;
+}
+
+.login-button {
+  margin-top: 0.35rem;
+  border: none;
+  border-radius: 16px;
+  padding: 0.95rem 1rem;
+  background: linear-gradient(135deg, var(--primary) 0%, var(--secondary) 100%);
+  color: #fff;
+  font-size: 0.96rem;
+  font-weight: 800;
+  box-shadow: 0 10px 20px rgba(255, 107, 157, 0.2);
+  transition: transform 0.2s, opacity 0.2s;
+}
+
+.login-button:hover:not(:disabled) {
+  transform: translateY(-1px);
+}
+
+.login-button:disabled {
+  opacity: 0.75;
+  cursor: not-allowed;
+}
+</style>

--- a/src/pages/SettingPage.vue
+++ b/src/pages/SettingPage.vue
@@ -1,9 +1,13 @@
 <script setup>
 import { ref, computed, watch } from 'vue'
+import { useRouter } from 'vue-router'
 import { useBudgetStore } from '../stores/useBudgetStore.js'
+import { useAuthStore } from '../stores/useAuthStore.js'
 import { usePigSystem } from '../composables/usePigSystem.js'
 
+const router = useRouter()
 const store = useBudgetStore()
+const authStore = useAuthStore()
 const { getHouseInfo, formatCurrency } = usePigSystem()
 
 const form = ref({
@@ -66,6 +70,15 @@ async function handleSave() {
   } catch (e) {
     errorMsg.value = '저장에 실패했어요. 다시 시도해주세요.'
   }
+}
+
+function handleLogout() {
+  const shouldLogout = window.confirm('로그아웃하시겠어요?')
+
+  if (!shouldLogout) return
+
+  authStore.logout()
+  router.replace('/login')
 }
 
 const HOUSE_LEVELS = [
@@ -202,6 +215,18 @@ const HOUSE_LEVELS = [
       <p class="info-desc">
         "내 소비의 주치의, 돼지 건강으로 보는 나의 재정 상태"
       </p>
+    </div>
+
+    <div class="logout-card">
+      <div class="logout-copy">
+        <h2 class="card-title">계정</h2>
+        <p class="logout-desc">
+          현재 로그인: {{ authStore.currentUser?.name || authStore.currentUser?.loginId || '사용자' }}
+        </p>
+      </div>
+      <button type="button" class="btn-logout" @click="handleLogout">
+        로그아웃
+      </button>
     </div>
 
     <!-- 돼지 상태 가이드 -->
@@ -342,6 +367,29 @@ const HOUSE_LEVELS = [
   padding: 1rem;
 }
 
+.logout-card {
+  background: linear-gradient(180deg, #fff 0%, #fff6f8 100%);
+  border: 1.5px solid #ffd7e5;
+  border-radius: 16px;
+  padding: 1rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.logout-copy {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.logout-desc {
+  font-size: 0.82rem;
+  color: var(--text-muted);
+  margin: 0;
+}
+
 .card-title {
   font-size: 0.95rem;
   font-weight: 700;
@@ -441,6 +489,17 @@ const HOUSE_LEVELS = [
 }
 
 .btn-save:disabled { opacity: 0.7; cursor: not-allowed; }
+
+.btn-logout {
+  border: 1px solid rgba(229, 90, 138, 0.18);
+  background: #fff;
+  color: var(--primary-dark);
+  border-radius: 12px;
+  padding: 0.85rem 1rem;
+  font-size: 0.9rem;
+  font-weight: 700;
+  white-space: nowrap;
+}
 
 /* Info Card */
 .info-list { display: flex; flex-direction: column; gap: 0; }

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -3,8 +3,11 @@ import HomePage from '../pages/HomePage.vue'
 import AccountPage from '../pages/AccountPage.vue'
 import StatisticsPage from '../pages/StatisticsPage.vue'
 import SettingPage from '../pages/SettingPage.vue'
+import LoginPage from '../pages/LoginPage.vue'
+import { getStoredAuthUser } from '../utils/auth.js'
 
 const routes = [
+  { path: '/login', name: 'Login', component: LoginPage, meta: { public: true, hideNav: true } },
   { path: '/', name: 'Home', component: HomePage },
   { path: '/account', name: 'Account', component: AccountPage },
   { path: '/statistics', name: 'Statistics', component: StatisticsPage },
@@ -14,6 +17,20 @@ const routes = [
 const router = createRouter({
   history: createWebHistory(),
   routes,
+})
+
+router.beforeEach((to) => {
+  const currentUser = getStoredAuthUser()
+
+  if (!to.meta.public && !currentUser) {
+    return { name: 'Login' }
+  }
+
+  if (to.name === 'Login' && currentUser) {
+    return { name: 'Home' }
+  }
+
+  return true
 })
 
 export default router

--- a/src/stores/useAuthStore.js
+++ b/src/stores/useAuthStore.js
@@ -1,0 +1,55 @@
+import { computed, ref } from 'vue'
+import { defineStore } from 'pinia'
+import axios from 'axios'
+import { clearStoredAuthUser, getStoredAuthUser, setStoredAuthUser } from '../utils/auth.js'
+
+const API_BASE = 'http://localhost:3000'
+
+export const useAuthStore = defineStore('auth', () => {
+  const currentUser = ref(getStoredAuthUser())
+  const loading = ref(false)
+  const error = ref('')
+
+  const isAuthenticated = computed(() => Boolean(currentUser.value))
+
+  async function login(loginId, password) {
+    loading.value = true
+    error.value = ''
+
+    try {
+      const res = await axios.get(`${API_BASE}/users?loginId=${encodeURIComponent(loginId)}&password=${encodeURIComponent(password)}`)
+      const user = Array.isArray(res.data) ? res.data[0] : null
+
+      if (!user) {
+        throw new Error('INVALID_CREDENTIALS')
+      }
+
+      currentUser.value = user
+      setStoredAuthUser(user)
+      return user
+    } catch (err) {
+      error.value =
+        err.message === 'INVALID_CREDENTIALS'
+          ? '아이디 또는 비밀번호가 올바르지 않습니다.'
+          : '로그인 중 문제가 발생했습니다. json-server 상태를 확인해 주세요.'
+      throw err
+    } finally {
+      loading.value = false
+    }
+  }
+
+  function logout() {
+    currentUser.value = null
+    error.value = ''
+    clearStoredAuthUser()
+  }
+
+  return {
+    currentUser,
+    loading,
+    error,
+    isAuthenticated,
+    login,
+    logout,
+  }
+})

--- a/src/stores/useBudgetStore.js
+++ b/src/stores/useBudgetStore.js
@@ -5,16 +5,14 @@ import axios from 'axios';
 const API_BASE = 'http://localhost:3000';
 
 export const useBudgetStore = defineStore('budget', () => {
-  // --- State ---
   const profile = ref(null);
   const records = ref([]);
   const incomeCategories = ref([]);
   const expenseCategories = ref([]);
-  const currentMonth = ref(new Date().toISOString().slice(0, 7)); // 'YYYY-MM'
+  const currentMonth = ref(new Date().toISOString().slice(0, 7));
   const loading = ref(false);
   const error = ref(null);
 
-  // --- Getters ---
   const monthlyRecords = computed(() =>
     records.value.filter((r) => r.date.startsWith(currentMonth.value)),
   );
@@ -66,11 +64,27 @@ export const useBudgetStore = defineStore('budget', () => {
     ...expenseCategories.value,
   ]);
 
-  // --- Actions ---
-  async function fetchProfile() {
+  async function fetchProfile(userId = '1') {
     try {
-      const res = await axios.get(`${API_BASE}/profile`);
-      profile.value = Array.isArray(res.data) ? res.data[0] : res.data;
+      const res = await axios.get(`${API_BASE}/profile?userId=${userId}`);
+      const matchedProfile = Array.isArray(res.data) ? res.data[0] ?? null : res.data;
+
+      if (matchedProfile) {
+        profile.value = matchedProfile;
+        return;
+      }
+
+      const fallbackRes = await axios.get(`${API_BASE}/profile`);
+      const fallbackProfile = Array.isArray(fallbackRes.data)
+        ? fallbackRes.data[0] ?? null
+        : fallbackRes.data;
+
+      profile.value = fallbackProfile
+        ? {
+            ...fallbackProfile,
+            userId: fallbackProfile.userId ?? userId,
+          }
+        : null;
     } catch (e) {
       error.value = '프로필 조회 실패';
       console.error(e);
@@ -112,7 +126,7 @@ export const useBudgetStore = defineStore('budget', () => {
       loading.value = true;
       const res = await axios.post(`${API_BASE}/records`, {
         ...newRecord,
-        userId: '1',
+        userId: profile.value?.userId ?? '1',
         createdAt: new Date().toISOString(),
       });
       records.value = [res.data, ...records.value].sort((a, b) =>
@@ -176,15 +190,23 @@ export const useBudgetStore = defineStore('budget', () => {
     }
   }
 
-  async function initStore() {
+  function resetStore() {
+    profile.value = null;
+    records.value = [];
+    incomeCategories.value = [];
+    expenseCategories.value = [];
+    error.value = null;
+  }
+
+  async function initStore(userId = '1') {
     loading.value = true;
     error.value = null;
     try {
       await Promise.all([
-        fetchProfile(),
+        fetchProfile(userId),
         fetchIncomeCategories(),
         fetchExpenseCategories(),
-        fetchRecords(),
+        fetchRecords(userId),
       ]);
     } finally {
       loading.value = false;
@@ -192,7 +214,6 @@ export const useBudgetStore = defineStore('budget', () => {
   }
 
   return {
-    // state
     profile,
     records,
     incomeCategories,
@@ -200,7 +221,6 @@ export const useBudgetStore = defineStore('budget', () => {
     currentMonth,
     loading,
     error,
-    // getters
     monthlyRecords,
     todayRecords,
     totalExpenseThisMonth,
@@ -211,7 +231,6 @@ export const useBudgetStore = defineStore('budget', () => {
     todayNetIncome,
     dailyBudget,
     allCategories,
-    // actions
     fetchProfile,
     fetchIncomeCategories,
     fetchExpenseCategories,
@@ -220,6 +239,7 @@ export const useBudgetStore = defineStore('budget', () => {
     updateRecord,
     deleteRecord,
     updateProfile,
+    resetStore,
     initStore,
   };
 });

--- a/src/utils/auth.js
+++ b/src/utils/auth.js
@@ -1,0 +1,22 @@
+const AUTH_USER_KEY = 'dondoc-auth-user'
+
+export function getStoredAuthUser() {
+  const raw = localStorage.getItem(AUTH_USER_KEY)
+
+  if (!raw) return null
+
+  try {
+    return JSON.parse(raw)
+  } catch {
+    localStorage.removeItem(AUTH_USER_KEY)
+    return null
+  }
+}
+
+export function setStoredAuthUser(user) {
+  localStorage.setItem(AUTH_USER_KEY, JSON.stringify(user))
+}
+
+export function clearStoredAuthUser() {
+  localStorage.removeItem(AUTH_USER_KEY)
+}


### PR DESCRIPTION
이번 변경은 크게 보면 "로그인 기능 추가"와 "로그아웃 기능 추가", 그리고 "사용자별로 데이터를 읽도록 기존 가계부 흐름 연결" 이 세 덩어리입니다. 초보자 기준으로 파일별 역할까지 풀어서 정리해드릴게요.

전체 흐름
처음에는 앱이 켜지면 바로 가계부 화면이 보이는 구조였는데, 지금은 먼저 로그인 여부를 확인합니다. 로그인하지 않았으면 로그인 페이지로 보내고, 로그인에 성공하면 그 사용자 정보로 가계부 데이터를 불러옵니다. 로그아웃하면 저장된 로그인 정보가 지워지고 다시 로그인 페이지로 돌아갑니다.

1. db.json에서 바뀐 점
파일: db.json

여기에 로그인용 users 데이터를 새로 추가했습니다.

"users": [
  {
    "id": "1",
    "loginId": "demo",
    "password": "1234",
    "name": "데모 사용자"
  }
]
이 뜻은:

loginId: 로그인할 때 입력하는 아이디
password: 로그인할 때 비교할 비밀번호
name: 화면에서 사용자 이름처럼 쓸 수 있는 값
id: 사용자 고유 번호
또 profile 안에도 userId를 넣었습니다.

이 뜻은:

users의 id와 profile.userId를 연결해서
"이 프로필은 어떤 사용자 것인지" 알 수 있게 만든 겁니다.
즉, 예전에는 그냥 프로필 1개를 무조건 가져왔고,
지금은 "로그인한 사용자 id에 맞는 프로필"을 찾는 구조로 바뀌었습니다.

2. 로그인 상태를 저장하는 파일 추가
파일: src/stores/useAuthStore.js

이 파일은 로그인 전용 Pinia 스토어입니다.
쉽게 말하면 "로그인 관련 데이터만 관리하는 창고"입니다.

여기서 하는 일:

현재 로그인한 유저 저장
로그인 처리
로그아웃 처리
로그인 중인지 여부 저장
에러 메시지 저장
핵심 함수는 2개입니다.

login(loginId, password)

db.json의 users에서 아이디/비밀번호가 맞는 사용자를 찾음
맞으면 currentUser에 저장
그리고 브라우저 localStorage에도 저장
그래서 새로고침해도 로그인 상태가 유지됨
logout()

currentUser를 null로 바꿈
localStorage에 저장된 로그인 정보도 삭제
즉, 이 파일은 "로그인 상태의 중심" 역할입니다.

3. 로그인 정보를 브라우저에 저장하는 유틸 파일 추가
파일: src/utils/auth.js

이 파일은 아주 단순한 보조 파일입니다.
로그인 정보를 localStorage에 넣고, 읽고, 지우는 함수만 모아뒀습니다.

들어있는 함수:

getStoredAuthUser()
setStoredAuthUser(user)
clearStoredAuthUser()
왜 따로 뺐냐면:

로그인 저장 로직을 한 파일에 몰아두면
나중에 수정하거나 재사용하기 쉬워집니다.
예를 들어 저장 키 이름을 바꾸고 싶을 때도 이 파일만 보면 됩니다.

4. 로그인 페이지 새로 추가
파일: src/pages/LoginPage.vue

이 파일이 실제 로그인 화면입니다.

들어간 기능:

아이디 입력창
비밀번호 입력창
로그인 버튼
빈칸 검사
아이디/비밀번호 틀렸을 때 에러 메시지 표시
로그인 성공 시 홈(/)으로 이동
handleLogin() 함수가 핵심입니다.
동작 순서는:

아이디/비밀번호 입력값 검사
authStore.login() 호출
성공하면 router.push('/')
실패하면 에러 문구 표시
디자인 쪽도 기존 앱 톤에 맞췄습니다.
기존 style.css의 색 변수인:

--primary
--primary-light
--secondary
--border
이런 값들을 그대로 써서 화면이 튀지 않게 맞췄습니다.

또 테스트용 안내도 넣었습니다.

아이디: demo
비밀번호: 1234
초보자 입장에서 보면,
이 페이지는 "사용자가 입력하는 화면",
useAuthStore.js는 "입력값을 실제로 검사하는 로직"
이라고 생각하면 이해가 쉽습니다.

5. 라우터에 로그인 페이지와 접근 제한 추가
파일: src/router/index.js

여기서 바뀐 건 2가지입니다.

/login 경로 추가
{ path: '/login', name: 'Login', component: LoginPage, meta: { public: true, hideNav: true } }
이 뜻은:

/login으로 들어가면 로그인 페이지를 보여준다
public: true는 로그인 안 해도 접근 가능한 페이지라는 뜻
hideNav: true는 하단 네비게이션 바를 숨기기 위한 표시
beforeEach 라우터 가드 추가
이 부분이 아주 중요합니다.
페이지 이동 전에 로그인 여부를 검사합니다.

동작:

로그인 안 한 상태에서 홈/가계부/통계/설정 페이지 가려고 하면 /login으로 보냄
이미 로그인했는데 /login으로 다시 가려고 하면 홈(/)으로 보냄
즉, "로그인 안 했으면 보호 페이지 못 들어가게 막는 문지기" 역할입니다.

6. 앱 전체에서 로그인 상태를 보고 화면을 다르게 보이게 수정
파일: src/App.vue

원래는 앱이 켜지면 무조건:

NavBar
RouterView
store.initStore()
이 흐름이었습니다.

지금은 바뀌었습니다.

추가된 핵심 개념:

showNavBar
watch(() => authStore.currentUser?.id, ...)
showNavBar

로그인된 상태이고
현재 페이지가 hideNav가 아닐 때만
하단 네비게이션 바를 보여줍니다.
그래서 로그인 페이지에서는 네비게이션 바가 안 보입니다.

watch(...)

로그인한 사용자가 바뀌는지 감시합니다.
로그인하면 그 사용자 id로 store.initStore(userId) 실행
로그아웃하면 store.resetStore() 실행
쉽게 말해:

로그인하면 가계부 데이터 불러오기
로그아웃하면 가계부 데이터 비우기
이걸 자동으로 처리하도록 만든 겁니다.

7. 기존 가계부 스토어를 사용자 기준으로 수정
파일: src/stores/useBudgetStore.js

이 파일은 원래 가계부 데이터를 관리하던 핵심 스토어입니다.
여기서 로그인 시스템과 연결되도록 바뀌었습니다.

주요 변경점은 4가지입니다.

fetchProfile(userId)로 변경
예전:
그냥 /profile 가져옴
지금:

/profile?userId=로그인유저아이디 로 가져옴
즉, 로그인한 사용자의 프로필을 찾습니다.

fetchRecords(userId) 유지/연결 강화
이건 이미 userId를 받는 구조였는데,
이제 로그인한 사용자 id를 실제로 넘겨서 사용하게 됐습니다.

addRecord()에서 userId 자동 설정
예전:

새 거래를 추가할 때 항상 userId: '1'
지금:

profile.value?.userId ?? '1'
즉, 현재 로그인한 사용자 기준으로 거래가 저장됩니다.

resetStore() 추가
로그아웃할 때
프로필
기록
카테고리
에러 상태
이런 걸 비워주는 함수입니다.

왜 필요하냐면,
로그아웃했는데 이전 사용자의 데이터가 화면에 남아 있으면 안 되기 때문입니다.

8. 로그아웃 버튼 추가
파일: src/pages/SettingPage.vue

설정 페이지에 로그아웃 UI를 추가했습니다.

추가된 것:

useRouter() import
useAuthStore() import
handleLogout() 함수
계정 카드 UI
로그아웃 버튼 스타일
handleLogout() 동작:

window.confirm('로그아웃하시겠어요?')
확인 누르면 authStore.logout()
router.replace('/login') 로 로그인 페이지 이동
그리고 화면에도

현재 로그인한 사용자 이름 또는 아이디
로그아웃 버튼
이 보이게 했습니다.

즉, 설정 페이지가 이제 "프로필 수정"뿐 아니라 "계정 관리" 역할도 조금 하게 된 겁니다.

파일별 한 줄 요약

db.json
로그인용 users 추가, 프로필에 userId 연결
src/stores/useAuthStore.js
로그인/로그아웃 상태 관리
src/utils/auth.js
localStorage 저장/조회/삭제
src/pages/LoginPage.vue
로그인 화면과 버튼 동작
src/router/index.js
/login 라우트 추가, 로그인 여부 검사
src/App.vue
로그인 상태에 따라 네비게이션 표시와 데이터 로딩 제어
src/stores/useBudgetStore.js
가계부 데이터를 로그인 사용자 기준으로 로딩/초기화
src/pages/SettingPage.vue
로그아웃 버튼과 계정 카드 추가
실제로 사용자 입장에서 어떻게 바뀌었는지
이전:

앱 실행하면 바로 가계부 페이지 진입
누구 사용자 데이터인지 구분이 약함
로그아웃 기능 없음
이후:

앱 실행 시 로그인 필요
로그인 성공 후에만 메인 화면 진입
로그인한 사용자 기준으로 프로필/기록 조회
설정 페이지에서 로그아웃 가능
로그아웃하면 다시 로그인 화면으로 이동
깃에 올릴 때 커밋 메시지 예시
짧게 쓰면:
feat: add login/logout flow with auth store and protected routes

한글로 쓰면:
feat: 로그인/로그아웃 기능 및 인증 라우팅 추가

추가로 같이 적으면 좋은 설명
PR이나 메모에 이렇게 적으면 좋아요.

json-server 기반의 간단한 로그인 기능 추가
Pinia로 인증 상태 관리
로그인 여부에 따라 라우팅 보호 적용
로그인 사용자 기준으로 프로필/기록 데이터 로딩
설정 페이지에 로그아웃 기능 추가
원하시면 제가 다음 답변에서
git add, git commit 할 때 바로 붙여넣을 수 있게
"커밋 메시지 + 변경사항 설명문" 형태로 정리해서 더 깔끔하게 써드릴게요.