### PR TITLE
fix(statistics탭 monthPicker): remove button 'x' of monthPicker

### DIFF
--- a/src/pages/StatisticsPage.vue
+++ b/src/pages/StatisticsPage.vue
@@ -1,21 +1,21 @@
 <script setup>
-import 'vue-datepicker-next/index.css';
-import DatePicker from 'vue-datepicker-next';
+import "vue-datepicker-next/index.css";
+import DatePicker from "vue-datepicker-next";
 
-import { computed, ref } from 'vue';
-import DailyLog from '../components/DailyLog.vue';
-import CalendarLog from '../components/CalendarLog.vue';
-import MonthlyLog from '../components/MonthlyLog.vue';
-import Summary from '../components/Summary.vue';
+import { computed, ref } from "vue";
+import DailyLog from "../components/DailyLog.vue";
+import CalendarLog from "../components/CalendarLog.vue";
+import MonthlyLog from "../components/MonthlyLog.vue";
+import Summary from "../components/Summary.vue";
 
 const selectedMonth = ref(new Date().toISOString().slice(0, 7));
-const activeTab = ref('summary'); // 'summary' | 'daily' | 'calendar' | 'monthly'
+const activeTab = ref("summary"); // 'summary' | 'daily' | 'calendar' | 'monthly'
 
 const tabs = [
-  { key: 'summary', label: '요약', icon: '📊' },
-  { key: 'daily', label: '일별', icon: '📅' },
-  { key: 'calendar', label: '달력', icon: '🗓️' },
-  { key: 'monthly', label: '월간', icon: '📆' },
+  { key: "summary", label: "요약", icon: "📊" },
+  { key: "daily", label: "일별", icon: "📅" },
+  { key: "calendar", label: "달력", icon: "🗓️" },
+  { key: "monthly", label: "월간", icon: "📆" },
 ];
 
 const months = computed(() => {
@@ -48,6 +48,7 @@ const months = computed(() => {
         placeholder="월 선택하기"
         :popup-style="{ right: '0px !important', transform: 'none !important' }"
         :append-to-body="false"
+        :clearable="false"
       ></date-picker>
     </div>
 


### PR DESCRIPTION
- 원인: 달력 컴포넌트 (CalendarLog.vue)에서는 selectedMonth가 무조건 YYYY-MM-DD가 전달된다고 생각하여 이 값을 split('-')을 통해 처리하고 있었음. 근데 null 값이 전달되니 오류가 발생한 것임
- 해결: 달력 선택기에서 'x 버튼 (아무 달도 선택하지 않기)' 제거하였음

close #19 