### PR TITLE
Feature/calendar log pre next month arrow #26

### DIFF
--- a/src/components/CalendarLog.vue
+++ b/src/components/CalendarLog.vue
@@ -13,7 +13,7 @@ const store = useBudgetStore();
 const { getPigState } = usePigSystem();
 
 const tooltip = ref(null); // 현재 호버된 day 데이터
-const tooltipPos = ref({}); // 툴팁 위치 (fixed 기준)
+const tooltipPos = ref({}); // 툴팁 위치 (fixed 기준) 준
 
 function showTooltip(event, day) {
   if (!day || (!day.pigState && day.income === 0 && day.expense === 0)) return;

--- a/src/components/CalendarLog.vue
+++ b/src/components/CalendarLog.vue
@@ -86,6 +86,22 @@ const calendarDays = computed(() => {
   return days;
 });
 
+const prevMonth = computed(() => {
+  const [year, month] = props.selectedMonth.split('-').map(Number)
+  const d = new Date(year, month - 2, 1) // month-1이 현재달, month-2가 이전달
+  return d.toISOString().slice(0, 7)
+})
+
+const nextMonth = computed(() => {
+  const [year, month] = props.selectedMonth.split('-').map(Number)
+  const d = new Date(year, month, 1) // month가 다음달 (0-based라서)
+  return d.toISOString().slice(0, 7)
+})
+
+const isCurrentMonth = computed(() => {
+  return props.selectedMonth === new Date().toISOString().slice(0, 7)
+})
+
 const selectedMonthLabel = computed(() => {
   const [year, month] = props.selectedMonth.split('-');
   return `${year}년 ${parseInt(month)}월`;
@@ -97,7 +113,7 @@ const selectedMonthLabel = computed(() => {
     <div class="calendar-title">
       <button class="month-arrow" @click="emit('update:selectedMonth', prevMonth)">◀</button>
       <span>{{ selectedMonthLabel }}</span>
-      <button class="month-arrow" @click="emit('update:selectedMonth', nextMonth)">▶</button>
+      <button class="month-arrow" @click="emit('update:selectedMonth', nextMonth)" :disabled="isCurrentMonth">▶</button>
     </div>
 
     <!-- 요일 헤더 -->
@@ -213,9 +229,14 @@ const selectedMonthLabel = computed(() => {
   transition: background 0.15s, color 0.15s;
 }
 
-.month-arrow:hover {
+.month-arrow:hover:not(:disabled) {
   background: var(--primary-light);
   color: var(--primary);
+}
+
+.month-arrow:disabled {
+  opacity: 0.3;
+  cursor: not-allowed;
 }
 
 .week-header {

--- a/src/components/CalendarLog.vue
+++ b/src/components/CalendarLog.vue
@@ -87,20 +87,20 @@ const calendarDays = computed(() => {
 });
 
 const prevMonth = computed(() => {
-  const [year, month] = props.selectedMonth.split('-').map(Number)
-  const d = new Date(year, month - 2, 1) // month-1이 현재달, month-2가 이전달
-  return d.toISOString().slice(0, 7)
-})
+  const [year, month] = props.selectedMonth.split('-').map(Number);
+  const d = new Date(year, month - 2, 1);
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}`;
+});
 
 const nextMonth = computed(() => {
-  const [year, month] = props.selectedMonth.split('-').map(Number)
-  const d = new Date(year, month, 1) // month가 다음달 (0-based라서)
-  return d.toISOString().slice(0, 7)
-})
+  const [year, month] = props.selectedMonth.split('-').map(Number);
+  const d = new Date(year, month, 1);
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}`;
+});
 
 const isCurrentMonth = computed(() => {
-  return props.selectedMonth === new Date().toISOString().slice(0, 7)
-})
+  return props.selectedMonth === new Date().toISOString().slice(0, 7);
+});
 
 const selectedMonthLabel = computed(() => {
   const [year, month] = props.selectedMonth.split('-');
@@ -111,9 +111,20 @@ const selectedMonthLabel = computed(() => {
 <template>
   <div class="calendar-log">
     <div class="calendar-title">
-      <button class="month-arrow" @click="emit('update:selectedMonth', prevMonth)">◀</button>
+      <button
+        class="month-arrow"
+        @click="emit('update:selectedMonth', prevMonth)"
+      >
+        ◀
+      </button>
       <span>{{ selectedMonthLabel }}</span>
-      <button class="month-arrow" @click="emit('update:selectedMonth', nextMonth)" :disabled="isCurrentMonth">▶</button>
+      <button
+        class="month-arrow"
+        @click="emit('update:selectedMonth', nextMonth)"
+        :disabled="isCurrentMonth"
+      >
+        ▶
+      </button>
     </div>
 
     <!-- 요일 헤더 -->
@@ -226,7 +237,9 @@ const selectedMonthLabel = computed(() => {
   cursor: pointer;
   padding: 2px 6px;
   border-radius: 6px;
-  transition: background 0.15s, color 0.15s;
+  transition:
+    background 0.15s,
+    color 0.15s;
 }
 
 .month-arrow:hover:not(:disabled) {

--- a/src/components/CalendarLog.vue
+++ b/src/components/CalendarLog.vue
@@ -94,7 +94,11 @@ const selectedMonthLabel = computed(() => {
 
 <template>
   <div class="calendar-log">
-    <p class="calendar-title">{{ selectedMonthLabel }}</p>
+    <div class="calendar-title">
+      <button class="month-arrow" @click="emit('update:selectedMonth', prevMonth)">◀</button>
+      <span>{{ selectedMonthLabel }}</span>
+      <button class="month-arrow" @click="emit('update:selectedMonth', nextMonth)">▶</button>
+    </div>
 
     <!-- 요일 헤더 -->
     <div class="week-header">
@@ -189,10 +193,29 @@ const selectedMonthLabel = computed(() => {
 }
 
 .calendar-title {
-  text-align: center;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
   font-weight: 700;
   font-size: 0.95rem;
   margin: 0;
+}
+
+.month-arrow {
+  background: none;
+  border: none;
+  font-size: 0.85rem;
+  color: var(--text-muted);
+  cursor: pointer;
+  padding: 2px 6px;
+  border-radius: 6px;
+  transition: background 0.15s, color 0.15s;
+}
+
+.month-arrow:hover {
+  background: var(--primary-light);
+  color: var(--primary);
 }
 
 .week-header {

--- a/src/components/CalendarLog.vue
+++ b/src/components/CalendarLog.vue
@@ -7,6 +7,8 @@ const props = defineProps({
   selectedMonth: { type: String, required: true },
 });
 
+const emit = defineEmits(['update:selectedMonth']);
+
 const store = useBudgetStore();
 const { getPigState } = usePigSystem();
 

--- a/src/pages/StatisticsPage.vue
+++ b/src/pages/StatisticsPage.vue
@@ -1,21 +1,21 @@
 <script setup>
-import "vue-datepicker-next/index.css";
-import DatePicker from "vue-datepicker-next";
+import 'vue-datepicker-next/index.css';
+import DatePicker from 'vue-datepicker-next';
 
-import { computed, ref } from "vue";
-import DailyLog from "../components/DailyLog.vue";
-import CalendarLog from "../components/CalendarLog.vue";
-import MonthlyLog from "../components/MonthlyLog.vue";
-import Summary from "../components/Summary.vue";
+import { computed, ref } from 'vue';
+import DailyLog from '../components/DailyLog.vue';
+import CalendarLog from '../components/CalendarLog.vue';
+import MonthlyLog from '../components/MonthlyLog.vue';
+import Summary from '../components/Summary.vue';
 
 const selectedMonth = ref(new Date().toISOString().slice(0, 7));
-const activeTab = ref("summary"); // 'summary' | 'daily' | 'calendar' | 'monthly'
+const activeTab = ref('summary'); // 'summary' | 'daily' | 'calendar' | 'monthly'
 
 const tabs = [
-  { key: "summary", label: "요약", icon: "📊" },
-  { key: "daily", label: "일별", icon: "📅" },
-  { key: "calendar", label: "달력", icon: "🗓️" },
-  { key: "monthly", label: "월간", icon: "📆" },
+  { key: 'summary', label: '요약', icon: '📊' },
+  { key: 'daily', label: '일별', icon: '📅' },
+  { key: 'calendar', label: '달력', icon: '🗓️' },
+  { key: 'monthly', label: '월간', icon: '📆' },
 ];
 
 const months = computed(() => {
@@ -52,7 +52,7 @@ const months = computed(() => {
       ></date-picker>
     </div>
 
-    <!-- 탭 네비게이션 -->
+    <!-- 탭 네비게이션 굿 -->
     <div class="tab-nav">
       <button
         v-for="tab in tabs"

--- a/src/pages/StatisticsPage.vue
+++ b/src/pages/StatisticsPage.vue
@@ -52,7 +52,7 @@ const months = computed(() => {
       ></date-picker>
     </div>
 
-    <!-- 탭 네비게이션 굿 -->
+    <!-- 탭 네비게이션 -->
     <div class="tab-nav">
       <button
         v-for="tab in tabs"

--- a/src/pages/StatisticsPage.vue
+++ b/src/pages/StatisticsPage.vue
@@ -76,6 +76,7 @@ const months = computed(() => {
       <CalendarLog
         v-else-if="activeTab === 'calendar'"
         :selectedMonth="selectedMonth"
+        @update:selectedMonth="selectedMonth = $event"
       />
       <MonthlyLog
         v-else-if="activeTab === 'monthly'"


### PR DESCRIPTION
현재 상태 (Current Behavior)
StatisticsPage.vue의 달력 탭에서 월을 변경하려면 상단 월 선택 드롭다운을 사용해야 함. 달력 화면 자체에서 직접 월을 이동할 수 없어 UX가 불편함.

목표 (Goal)
달력 탭의 상단 타이틀("2026년 4월") 좌우에 화살표 버튼을 추가해 이전 달 / 다음 달로 바로 이동 가능하게 함.

작업 내용 (Tasks)
CalendarLog.vue 타이틀 영역에 ◀ / ▶ 화살표 버튼 추가
이전 달 / 다음 달 클릭 시 selectedMonth 변경 emit
StatisticsPage.vue에서 emit 받아 selectedMonth 업데이트
미래 달로는 이동 불가 처리 (다음 달 버튼 비활성화)

관련 파일
src/components/CalendarLog.vue
src/pages/StatisticsPage.vue